### PR TITLE
fix: fixed a problem when getting Android ip

### DIFF
--- a/src/android/org/bcsphere/wifi/BCWifi.java
+++ b/src/android/org/bcsphere/wifi/BCWifi.java
@@ -27,7 +27,7 @@ public class BCWifi extends CordovaPlugin {
 				obj.put("BSSID", wifiInfo.getBSSID());
 				obj.put("SSID", wifiInfo.getSSID());
 				obj.put("MacAddress", wifiInfo.getMacAddress());
-				obj.put("IPAddress", wifiInfo.getIpAddress());
+				obj.put("IPAddress", convertIp2Str(wifiInfo.getIpAddress()));
 			} catch (JSONException e) {
 				e.printStackTrace();
 				callbackContext.error("JSON Exception");
@@ -35,5 +35,14 @@ public class BCWifi extends CordovaPlugin {
 			callbackContext.success(obj);
 		}
 		return true;
+	}
+
+	private static String convertIp2Str(int ip) {
+		String result;
+
+		result = String.format("%d.%d.%d.%d", (ip & 0xff), (ip >> 8 & 0xff), (ip >> 16 & 0xff),
+				(ip >> 24 & 0xff));
+
+		return result;
 	}
 }


### PR DESCRIPTION
On Android, the getIpAddress function wasn't returning the correct IP string.

I've updated it to match the iOS plugin.
